### PR TITLE
Update Node to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Ignore Lint Warnings'
     default: false    
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'check-square'


### PR DESCRIPTION
Node should be updated to v20 according to the Github warning:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: yutailang0119/action-android-lint@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

@yutailang0119 please check this PR and merge it if you agree